### PR TITLE
 converter: Add turndown rules to process footnotes

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -9,6 +9,19 @@ const turndownService = new TurndownService({ headingStyle: 'atx' })
 // taskListItems
 turndownService.use(turndownPluginGfm.gfm)
 
+const footnoteRefRule = {
+    filter: (node) => node.parentNode.getAttribute('class') === 'FootnoteRef',
+    replacement: (content) => content.replace(/\\/g, '').replace('[note: ', '[^'),
+}
+
+const footnoteRule = {
+    filter: (node) => node.parentNode.parentNode.getAttribute('class') === 'Footnote',
+    replacement: (content) => content.replace(/\\/g, '').replace('[note: ', '[^') + ': ',
+}
+
+turndownService.addRule('FootnoteRef', footnoteRefRule)
+turndownService.addRule('Footnote', footnoteRule)
+
 const getRequest = async (url) => {
     try {
         const response = await got(url)
@@ -85,6 +98,9 @@ const htmlToMarkdown = (html, url) => {
 
     // Remove non-utf-8 characters
     markdown = markdown.replace(/\uFFFD/g, '')
+
+    // Add footnote formatting
+    markdown = `<style>.footnotes::before { content: "Footnotes:"; }</style>` + markdown
 
     // Add source url at the bottom
     markdown += `\n\n\nSource: [link](${url})`

--- a/converter.js
+++ b/converter.js
@@ -34,8 +34,7 @@ const replaceHeaderClassesWithTags = ($, headerPrefix, maxLevel = 4, padLevel = 
     }
 }
 
-const getMarkdownFromUrl = async (url) => {
-    const html = await getRequest(url)
+const htmlToMarkdown = (html, url) => {
     let $ = cheerio.load(html)
     let content = $('.contentsOfFile').html()
     // fallbacks
@@ -105,7 +104,13 @@ const getMarkdownFromUrl = async (url) => {
     }
 }
 
+const getMarkdownFromUrl = async (url) => {
+    const html = await getRequest(url)
+    return htmlToMarkdown(html, url)
+}
+
 module.exports = {
     getRequest,
     getMarkdownFromUrl,
+    htmlToMarkdown,
 }


### PR DESCRIPTION
- extract and expose `htmlToMarkdown()`

- Instruct turndown to look out for footnote-related nodes, and convert
  them into footnotes recognised by Jekyll/Markdown

- Add some CSS to explicitly indicate the footnote list